### PR TITLE
Add Markdown parse mode with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Send a message to a Telegram chat or channel
 | `chatId` | string | number | Yes | The chat ID or channel username (e.g., @channelname or -1001234567890) |
 | `text` | string | Yes | The message text to send |
 | `topicId` | number |  | The topic ID for forum channels (optional) |
+| `parseMode` | string |  | Optional parse mode: `Markdown`, `MarkdownV2`, `HTML`, or `Text` (plain text) |
 
 <!-- AUTO-GENERATED TOOLS END -->
 

--- a/src/sampling/handler.ts
+++ b/src/sampling/handler.ts
@@ -235,6 +235,7 @@ export class SamplingHandler {
 					responseText,
 					request.templateData.topicId,
 					request.messageId,
+					{ parseMode: "Markdown", fallbackToPlainText: true },
 				);
 			}
 

--- a/src/services/telegram-service.ts
+++ b/src/services/telegram-service.ts
@@ -65,6 +65,7 @@ export class TelegramService {
 				sendOptions?.parseMode === undefined ? "Markdown" : sendOptions.parseMode;
 			const shouldFallback = sendOptions?.fallbackToPlainText ?? true;
 
+			// null parseMode = plain text (no formatting), used when "Text" is selected in SEND_MESSAGE
 			if (!parseMode) {
 				const message = await this.bot.telegram.sendMessage(
 					chatId,

--- a/src/services/telegram-service.ts
+++ b/src/services/telegram-service.ts
@@ -34,7 +34,7 @@ export class TelegramService {
 		replyToMessageId?: number,
 	): Promise<MessageInfo> {
 		try {
-			const options: {
+			const baseOptions: {
 				message_thread_id?: number;
 				reply_parameters?: {
 					message_id: number;
@@ -43,28 +43,42 @@ export class TelegramService {
 			} = {};
 
 			if (typeof topicId === "number") {
-				options.message_thread_id = topicId;
+				baseOptions.message_thread_id = topicId;
 			}
 
 			if (typeof replyToMessageId === "number") {
-				options.reply_parameters = {
+				baseOptions.reply_parameters = {
 					message_id: replyToMessageId,
 					allow_sending_without_reply: true,
 				};
 			}
 
-			const message = await this.bot.telegram.sendMessage(
-				chatId,
-				text,
-				options,
-			);
+			try {
+				const message = await this.bot.telegram.sendMessage(chatId, text, {
+					...baseOptions,
+					parse_mode: "Markdown",
+				});
 
-			return {
-				messageId: message.message_id,
-				chatId: message.chat.id,
-				text: message.text,
-				date: message.date,
-			};
+				return {
+					messageId: message.message_id,
+					chatId: message.chat.id,
+					text: message.text,
+					date: message.date,
+				};
+			} catch {
+				const message = await this.bot.telegram.sendMessage(
+					chatId,
+					text,
+					baseOptions,
+				);
+
+				return {
+					messageId: message.message_id,
+					chatId: message.chat.id,
+					text: message.text,
+					date: message.date,
+				};
+			}
 		} catch (error) {
 			throw new Error(
 				`Failed to send message: ${error instanceof Error ? error.message : "Unknown error"}`,

--- a/src/services/telegram-service.ts
+++ b/src/services/telegram-service.ts
@@ -16,6 +16,13 @@ export interface MessageInfo {
 	date: number;
 }
 
+export type TelegramParseMode = "Markdown" | "MarkdownV2" | "HTML";
+
+export interface SendMessageOptions {
+	parseMode?: TelegramParseMode | null;
+	fallbackToPlainText?: boolean;
+}
+
 export class TelegramService {
 	private bot: Telegraf;
 
@@ -32,6 +39,7 @@ export class TelegramService {
 		text: string,
 		topicId?: number,
 		replyToMessageId?: number,
+		sendOptions?: SendMessageOptions,
 	): Promise<MessageInfo> {
 		try {
 			const baseOptions: {
@@ -53,10 +61,29 @@ export class TelegramService {
 				};
 			}
 
+			const parseMode =
+				sendOptions?.parseMode === undefined ? "Markdown" : sendOptions.parseMode;
+			const shouldFallback = sendOptions?.fallbackToPlainText ?? true;
+
+			if (!parseMode) {
+				const message = await this.bot.telegram.sendMessage(
+					chatId,
+					text,
+					baseOptions,
+				);
+
+				return {
+					messageId: message.message_id,
+					chatId: message.chat.id,
+					text: message.text,
+					date: message.date,
+				};
+			}
+
 			try {
 				const message = await this.bot.telegram.sendMessage(chatId, text, {
 					...baseOptions,
-					parse_mode: "Markdown",
+					parse_mode: parseMode,
 				});
 
 				return {
@@ -65,7 +92,11 @@ export class TelegramService {
 					text: message.text,
 					date: message.date,
 				};
-			} catch {
+			} catch (error) {
+				if (!shouldFallback || !isParseModeError(error)) {
+					throw error;
+				}
+
 				const message = await this.bot.telegram.sendMessage(
 					chatId,
 					text,
@@ -174,4 +205,17 @@ export class TelegramService {
 			);
 		}
 	}
+}
+
+function isParseModeError(error: unknown): boolean {
+	if (!(error instanceof Error)) {
+		return false;
+	}
+
+	const normalizedMessage = error.message.toLowerCase();
+	return (
+		normalizedMessage.includes("can't parse entities") ||
+		normalizedMessage.includes("cannot parse entities") ||
+		normalizedMessage.includes("parse entities")
+	);
 }

--- a/src/tools/send-message.ts
+++ b/src/tools/send-message.ts
@@ -37,6 +37,7 @@ export const sendMessageTool = {
 				params.topicId,
 				undefined,
 				{
+					// "Text" is a synthetic value meaning plain text — map to null (no parse_mode sent to Telegram)
 					parseMode: params.parseMode === "Text" ? null : params.parseMode,
 				},
 			);

--- a/src/tools/send-message.ts
+++ b/src/tools/send-message.ts
@@ -13,6 +13,12 @@ const sendMessageParams = z.object({
 		.number()
 		.optional()
 		.describe("The topic ID for forum channels (optional)"),
+	parseMode: z
+		.enum(["Markdown", "MarkdownV2", "HTML", "Text"])
+		.optional()
+		.describe(
+			"Parse mode for Telegram rendering. Use Text for plain text without formatting.",
+		),
 });
 
 type SendMessageParams = z.infer<typeof sendMessageParams>;
@@ -29,6 +35,10 @@ export const sendMessageTool = {
 				params.chatId,
 				params.text,
 				params.topicId,
+				undefined,
+				{
+					parseMode: params.parseMode === "Text" ? null : params.parseMode,
+				},
 			);
 
 			return dedent`

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -52,6 +52,24 @@ describe("MCP Tools", () => {
 			});
 			expect(result.success).toBe(true);
 		});
+
+		it("should accept optional parseMode", () => {
+			const result = sendMessageTool.parameters.safeParse({
+				chatId: "@testchannel",
+				text: "Hello",
+				parseMode: "HTML",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept parseMode Text for plain messages", () => {
+			const result = sendMessageTool.parameters.safeParse({
+				chatId: "@testchannel",
+				text: "Hello",
+				parseMode: "Text",
+			});
+			expect(result.success).toBe(true);
+		});
 	});
 
 	describe("getChannelInfoTool", () => {


### PR DESCRIPTION
TelegramService.sendMessage() in @iqai/mcp-telegram doesn't set parse_mode on the Telegraf sendMessage call. All bot responses render as plain text — markdown formatting (bold, italic, code blocks, links) appears as raw characters instead of being rendered.