### PR TITLE
chore: rename IQAICOM/IQAIcom to IQOfficial

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npx @iqai/mcp-telegram
 ### Build from Source
 
 ```bash
-git clone https://github.com/IQAIcom/mcp-telegram.git
+git clone https://github.com/IQOfficial/mcp-telegram.git
 cd mcp-telegram
 pnpm install
 pnpm run build

--- a/progress.txt
+++ b/progress.txt
@@ -59,5 +59,5 @@ Update mcp-telegram: cd into mcp-telegram, create branch feat/standardize-readme
 - Linting passes: `pnpm run lint`
 
 ### PR
-- PR #14: https://github.com/IQAIcom/mcp-telegram/pull/14
+- PR #14: https://github.com/IQOfficial/mcp-telegram/pull/14
 - Status: Merged


### PR DESCRIPTION
Renames `IQAICOM`, `IQAIcom`, and `iqaicom` references to `IQOfficial` / `iqofficial` (case-preserving) as part of the brand handle rename. Covers Twitter/X handles, GitHub URLs, Telegram links, package metadata, badges, and docs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>